### PR TITLE
fix: #60.

### DIFF
--- a/src/client/java/dev/spiritstudios/snapper/mixin/InGameHudMixin.java
+++ b/src/client/java/dev/spiritstudios/snapper/mixin/InGameHudMixin.java
@@ -1,0 +1,30 @@
+package dev.spiritstudios.snapper.mixin;
+
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import dev.spiritstudios.snapper.gui.screen.PanoramaViewerScreen;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.hud.InGameHud;
+import net.minecraft.client.gui.screen.DownloadingTerrainScreen;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(InGameHud.class)
+public class InGameHudMixin {
+
+    @Shadow
+    @Final
+    private MinecraftClient client;
+
+    @Definition(id = "DownloadingTerrainScreen", type = DownloadingTerrainScreen.class)
+    @Definition(id = "client", field = "Lnet/minecraft/client/gui/hud/InGameHud;client:Lnet/minecraft/client/MinecraftClient;")
+    @Definition(id = "currentScreen", field = "Lnet/minecraft/client/MinecraftClient;currentScreen:Lnet/minecraft/client/gui/screen/Screen;")
+    @Expression("(this.client.currentScreen instanceof DownloadingTerrainScreen)")
+    @ModifyExpressionValue(method = "render", at = @At(value = "MIXINEXTRAS:EXPRESSION"))
+    private boolean cancelRenderingHudInPanoramaScreen(boolean original) {
+        return original || client.currentScreen instanceof PanoramaViewerScreen;
+    }
+}

--- a/src/client/resources/snapper.mixins.json
+++ b/src/client/resources/snapper.mixins.json
@@ -6,6 +6,7 @@
     "CameraMixin",
     "GameMenuMixin",
     "KeyboardMixin",
+    "InGameHudMixin",
     "MinecraftClientMixin",
     "ScreenshotRecorderMixin",
     "TitleScreenMixin",
@@ -14,5 +15,8 @@
   ],
   "injectors": {
     "defaultRequire": 1
+  },
+  "mixinextras": {
+    "minVersion": "0.5.0"
   }
 }


### PR DESCRIPTION
Resolves #60.

Mixins to where DownloadingTerrainScreen disallows rendering the in game hud elements (hotbar, active status effects, etc) to share this behavior to PanromaViewerScreen.